### PR TITLE
Rezultati zadnjega poizkusa

### DIFF
--- a/seznam_protiprimerov.json
+++ b/seznam_protiprimerov.json
@@ -1,0 +1,19 @@
+[
+  ":]c@A_agE`gblKaCDbKbFJkgH`Ft?lNS_DEpQiSlTXhSTjPWfIR", 
+  ":]b@_B_hG`hfI`CfadHeandJMeIObLQjKRgPeMPg_FQnRYaWY", 
+  ":]a?d?f?EeeakCgJ`DH`J`ABqINfJbPRbchTdIPkUVlPQtcGZkUZ", 
+  ":g`?H?AGGe_wOiLADrW_qSJeoxxQAP``wo}IOKoOg]GMbaH[?IKhfiHQcTMQapyATOqPd_y_bDsn", 
+  ":qb?h?]N?arO[iSKfOWc_VOj?G_W^LHRG[QyDcAQlWo[afWXSlPbAqSGwalsAdLDPMuraUgX_bcDdP?TJGwtN@@Hh`hJHIen", 
+  ":q`_G[_BKBAxS{@PCOwKc\\HHpPkGGQiqpxI_RabH@a{OMPHsWs\\abwwmYZggCSCN?JF{AYMbcfgQi[SbCRm`Qkmft[goc`AaF", 
+  ":qc_GKoPGcpHcygL_cx[o[OapWkGZEdFHCKGJbCqtctUKfg?GNHDCWxIGPKO?W}pADoRQE]TLscieMQNOqXqK\\STDD?go", 
+  ":{d@hgm?D`OYO]IPi_X?qTFeopXUaUmbAxqRLofIDfIGHGWiLHFCqCSORPLiYyaEQKsBamEIOTXxLB??_gaAK]NvczIWbVoBAQg^QPBAICSVrqaAKJF^", 
+  ":{a?GoAQFe@Xoq_EDOxCWZIFt_|_fQIdgk?lD`UhOnAAMQ@HEpCGwIkKVAMgYEXNJIFHiNL@JtQyMW_UUbYUAWQORqyMHUrsiuY_Sp@s`Qi`drs{y^fCe~", 
+  ":{f?XLCKF`qxtWSR`ahHQfBIo_`APObuWtC{^hWG_]JGJEgiM][dbPsGQ^jgccGpGIGhhI?TRr@iUAK_`RK@@[Mo?dxIrdBAkW_pfiEcl[tmgtf", 
+  ":{c_XoKTO@S`TOINgpWGuAHbpqTKnEGCgW{tIIOAsObJJWp`U?CNX`X@DLcGc{_WaepJH|VRPizADTGrp`xfInWO`s@?oheskcir`@wYUUiZpOoqan[^", 
+  ":{a?_[[F@bRPCAOJaTQTKhWBDwDYIRbailv?IFUxaAgVebr|iIHOoope?PecYCGi^dcgh`JKFQPPyUSPOPc\\IptJiILR@TOaXi{^OttDHWrkfUl?ww", 
+  ":~?@E`oU?a_AK@h?@c_IS@xWH`@IXBwOOf`EEEWkNepub?OUGFG{Wa_kRdP_aeP}EGXCY`qiKDh]DEG_K`A}MFAABBPyLEwgaIxKdc@uRIAe@CPYLBbA[GrMBdAuHFbUJDGGkLgKTMwcZGg?TJgwcNhszNGGQJ^", 
+  ":~?@Ea_CGbOUN?wuG__]Ea@AHb@MX@GAAB`i\\@pA@apOW`w}c@_yK_wubdqYYGwcidQOeayI?BHCm`@C[e@yRHYkmdpwo`aA@@PUJGbMDEX[[GWKfII?dIG?IEYKx_a[l`@WugQclb`GneBGsaPoabps}", 
+  ":~?@E`_AI@woCaHGP_GQUAPEAAwUZ?o]\\?@aDBg_QfwI@DPq@@?qRE`yH_`g_a`aLHWCD_pmHbxCTEWo_bQeGDAUJkq_q`owi`_{[gRIJBqqEERYBFHWjJgwScA]VGX?XMXspNX?jjrCqabKzcrp?dPiQJCR", 
+  ":~?@E`oUJ@gwGAg?JcOILd?CFdpAKcPYDd@aBDXwRFI?IExKVd`}c?OIgB@Gb_GKcaOkKbPgdc@uCHgcNc@GRfggPFWWGHWOYHX{hKW?@IgcTFx]FHa]\\GWKhdRmlKRabHa}AB`aUERiDHrqbMGOEHws_Gg_mOn", 
+  ":~?@E__EE?WIH?O]JA?iMAWaMd??O`?qNcGUUbPUX_wAWg?qFgoGYFwQLcaEg@PY[HGsNj@{ffQWhgamPC`q_HqmQEwm\\JhKi_@Ka_q_sgQIDKhCdcp_r_p{da`yEMWgvMJC{NW_VHwOEBhc_HHCVFgoSJHkjKn"
+]

--- a/seznam_protiprimerov3.json
+++ b/seznam_protiprimerov3.json
@@ -1,0 +1,22 @@
+[
+  ":g`_h?M@J?pXOqPAco?dKCK_cG`CdIDpQ[WTJapg{O\\VLFWHGrFKExo{lSKrraIMLMQQPmEELO@@B", 
+  ":ga?HOaACf?`L?\\EDpgW}BNHpPhEhBEPw?UONJprKsjFGEXhGxHJeH`uKOIO__iQKHO?YEIGLOOOj", 
+  ":g`?GGIM?c_X_ILGCqh[AVOGsg`MEEaTQssnDDCGg}LIGoQcO[QcBB\\]q[NQPxQMLOppXuIWOq@`r", 
+  ":ga?WoASFa@O{s@@gBGgqbGi_ADACFCRg[GjIHCxGghLHOOg}EHKr@xaGLHo`xQOSKP`KK[\\bDbTWqc", 
+  ":q`_HOeNOBbGcu?A`BxxEmEcax_ylPcEhCyH^a`atSoYadxp]GHLqrYM]QQRAXQCLMO@iAEGOPOxIABGPbHuSUNOPPyA\\N~", 
+  ":qc?XCeLDaS?GQcLGoIK?ADaCGWiPJJRYxaMXbbgWeDJ`FsDgxFHVc[ACMGqckW]aaeCko]R`bqcxHShedcWufeFTl|?l", 
+  ":qb?OcEDJ?qxoucEiAh@QRH_BX{gXDKrB[GSLaOrSSb?@SbeIMOfBq[{cXbawXOpOGfg?OJRJhGXLFHIdiqDNMGFyH[|GOG~", 
+  ":qa_gwQ@Ae??GYIJdS?[yON`QIwW\\EErqTkEJJOyh[xIKUi@YbFDcZ{cx@HqRS?eSbdS[C^YQXdTPAjaGTKO_bdDQtw}_aeSn", 
+  ":qa?X?IUE`qw_U?Gh?`k]kDIsYPKhOdO`cCTFItbkCXDDeXTc~EIdx{cuc_CCLOtBNGW?_hHMYg_XHBPHxH\\VFGcxh?tMGi~", 
+  ":{a`GwISD`RPS{V?a@iWgdU?bg[shY@bxdeLGJurc_[P_BAEKZMLsHH`FHIGk\\UihmFgyTT@PTBK?rQSiwwaIcSRDjEENMoaiUcaSTrPuAJJQT{W}maCvN", 
+  ":{b@HGQUHaRoCAeIEtPSK]PadJGm\\AGPaCctKLo?HM^]aug{KLPIDWO\\FFKHGhEA_eqsLqO\\qIwGx^AEjYPdVQIjXAHJXPq`aqg_SotQyc`PQAxa[WY~", 
+  ":{`_GgEMCAr`SmcK_ohC}oVeP`s_`PJQ`kR?AFFhXQfEKfYP}QRKVhP|L@@aKcSnKPRSKGLPIF}?k_[jIXxHLCKjwWdZHIjxh\\DFGeG@TT?Tjy@lRYUK^", 
+  ":{b@WCcFCe`pCIaDerxGmkMeCI\\aUXmAqhaCKIrrSYXCCo@DUAI_gKxE[aafyA@FEBf{k?OVhHtcGEenGyq`RPLjKsC_`iEWXHHfYp@PYuoXrrYYerZ~", 
+  ":{a?WoA_I`?pDK@FCpiwunDHDZXapBIUgW{xLLpq@NEJHRBiAkZjrg__VK`AtLMkYRQSQY?MQoPxUMYNQS{C\\INGxg{lISo_iIGfWvERU_QTp`aIIGT~", 
+  ":{`_HWeGECO?cEJP@qqDEDFhRjGYuImabL{hZbfkL}SXOQ@KK^NLPApqIJlfSDiQ[cECs?mW___l?iUhecSG_]_i[QM[RISRyUo]XrQyMK[RptZQijU^", 
+  ":{`_XWIYJg?g?q^IFPGs}\\XBAWwaZWjO@xmIRa`r{om\\dOAkgobaerdqMXfDBCDNBHP?oeQVuPAAuOPmogHYsaWopYYWiikhi|`GPHljDjOHKIadl", 
+  ":{caHWI[IbSO\\KOOhT_d?aU_Ags?[NmCxpIZKIEwpUZ_lgkg?TAHOcddBiJHCk_UTeBwh@RTMOPhyE[QOO_eEfUPrYeMbSpRAYgadfUsdAga@qKCqmabBv", 
+  ":{b@HOaFL?_xKYXBh_XCA^@ACWhYsOHQYkYfDDezlqk]erhPQtC_DCclDAMgxxeWegqQC_i``Etk[cfriTdKqe_@rcSMWfFd[GSboHClHAmeJZI@t", 
+  ":~?@Ea_ACb_mO?OuQBXOD@hWBbhMYCho@CpUMbwgKb?}@dWW]`Oab`oe?Fxm`GgOPCwSS`@egJG_ZHX?Ye@eBGhg\\HGGLJWGPIX[g_?GHgQ{oaa[pdxCx_o[_aOoWhhWxfaS}`o_Zd`c\\ao{TcamtMbuENSN", 
+  ":~?@E`oEH@wkDbO?Ec?QSBP?Pd_UHBGAC_WWPa`MTa_}Ha@c]cHMdA@aKD`qgBiMQ_iIMGQeFFq]JGXGTIwSPhREVEa}fIQiBDaI@EgYGIAqNGqQbLwGTIgKCLwKMFw?AFXc\\Kg{QHx_gaqkka`kycqP@bAOu"
+]


### PR DESCRIPTION
Tukaj so še dosedanji rezultati iz zadnjega poganjanja:

* V `seznam_protiprimerov.json` so nepobarvani grafi iz poganjanja `veliki_grafi.sage`. Za vsako velikost se je generiralo 5 grafov, algoritem pa je uspel pobarvati vse grafe do 20 vozlišč, dva na 30 vozliščih, štiri na 40 vozliščih in dva na 50 vozliščih, medtem ko pri nobenem grafu na 60 ali 70 vozliščih ni bil uspešen. Pri zadnjem (petem) grafu na 70 vozliščih sem izvajanje prekinil približno na polovici.

* V `seznam_protiprimerov3.json` so še nepobarvani grafi izmed prvih 26 grafov v `seznam_protiprimerov2.json`. Algoritem je uspel pobarvati 6 od teh grafov - edinega na 30 vozliščih, dva (od 6) na 40 vozliščih in 3 (od 8) na 50 vozliščih - ni pa uspel pobarvati nobenega od 9 grafov na 60 vozliščih, kot tudi ne še dveh na 70 vozliščih (pri zadnjem sem izvajanje prekinil nekaj čez polovico).

Poganjanje algoritmov se sicer nadaljuje - če se pojavi še kaj zanimivega, vama pošljem.