### PR TITLE
Barvanje preostalih grafov na 70 vozliščih ni uspelo

### DIFF
--- a/seznam_protiprimerov.json
+++ b/seznam_protiprimerov.json
@@ -15,5 +15,7 @@
   ":~?@Ea_CGbOUN?wuG__]Ea@AHb@MX@GAAB`i\\@pA@apOW`w}c@_yK_wubdqYYGwcidQOeayI?BHCm`@C[e@yRHYkmdpwo`aA@@PUJGbMDEX[[GWKfII?dIG?IEYKx_a[l`@WugQclb`GneBGsaPoabps}", 
   ":~?@E`_AI@woCaHGP_GQUAPEAAwUZ?o]\\?@aDBg_QfwI@DPq@@?qRE`yH_`g_a`aLHWCD_pmHbxCTEWo_bQeGDAUJkq_q`owi`_{[gRIJBqqEERYBFHWjJgwScA]VGX?XMXspNX?jjrCqabKzcrp?dPiQJCR", 
   ":~?@E`oUJ@gwGAg?JcOILd?CFdpAKcPYDd@aBDXwRFI?IExKVd`}c?OIgB@Gb_GKcaOkKbPgdc@uCHgcNc@GRfggPFWWGHWOYHX{hKW?@IgcTFx]FHa]\\GWKhdRmlKRabHa}AB`aUERiDHrqbMGOEHws_Gg_mOn", 
-  ":~?@E__EE?WIH?O]JA?iMAWaMd??O`?qNcGUUbPUX_wAWg?qFgoGYFwQLcaEg@PY[HGsNj@{ffQWhgamPC`q_HqmQEwm\\JhKi_@Ka_q_sgQIDKhCdcp_r_p{da`yEMWgvMJC{NW_VHwOEBhc_HHCVFgoSJHkjKn"
+  ":~?@E__EE?WIH?O]JA?iMAWaMd??O`?qNcGUUbPUX_wAWg?qFgoGYFwQLcaEg@PY[HGsNj@{ffQWhgamPC`q_HqmQEwm\\JhKi_@Ka_q_sgQIDKhCdcp_r_p{da`yEMWgvMJC{NW_VHwOEBhc_HHCVFgoSJHkjKn", 
+  "Oa?MJ@W]EcO}ObGCM_hgW___Hawu^A?kX_wMV_PKVeAAeCYYHePyYa_oLeQIHiggOgQSeb_{UcqENc`i]JhUDJX_hLWWkJiSfIIUCKh[uMxWlMxWgNGAILG?Fc@G[b`O]fY{rPXSfKwS[__[i`c@AfQPDgBX@_?P?gb\\G_OOP", 
+  ":~?@Y`?I?a?OEaoENAW?Ac_U@`wIEe?AJDpaZDxs[foKNbhQWc`M@@Gob`OygEgW]iICaegeFIyYKGG{]IhGll?gLl`]n_pmdKxUFDgKILjWwiWsfJhqkd`okb?s}cPsreaCahAgva`?olRiPHy[xcSAMJRyrLG_SdP|@crt?msDJqCdIkgctLy|LRgktSxkySxs_fa`W"
 ]

--- a/seznam_protiprimerov3.json
+++ b/seznam_protiprimerov3.json
@@ -18,5 +18,9 @@
   ":{caHWI[IbSO\\KOOhT_d?aU_Ags?[NmCxpIZKIEwpUZ_lgkg?TAHOcddBiJHCk_UTeBwh@RTMOPhyE[QOO_eEfUPrYeMbSpRAYgadfUsdAga@qKCqmabBv", 
   ":{b@HOaFL?_xKYXBh_XCA^@ACWhYsOHQYkYfDDezlqk]erhPQtC_DCclDAMgxxeWegqQC_i``Etk[cfriTdKqe_@rcSMWfFd[GSboHClHAmeJZI@t", 
   ":~?@Ea_ACb_mO?OuQBXOD@hWBbhMYCho@CpUMbwgKb?}@dWW]`Oab`oe?Fxm`GgOPCwSS`@egJG_ZHX?Ye@eBGhg\\HGGLJWGPIX[g_?GHgQ{oaa[pdxCx_o[_aOoWhhWxfaS}`o_Zd`c\\ao{TcamtMbuENSN", 
-  ":~?@E`oEH@wkDbO?Ec?QSBP?Pd_UHBGAC_WWPa`MTa_}Ha@c]cHMdA@aKD`qgBiMQ_iIMGQeFFq]JGXGTIwSPhREVEa}fIQiBDaI@EgYGIAqNGqQbLwGTIgKCLwKMFw?AFXc\\Kg{QHx_gaqkka`kycqP@bAOu"
+  ":~?@E`oEH@wkDbO?Ec?QSBP?Pd_UHBGAC_WWPa`MTa_}Ha@c]cHMdA@aKD`qgBiMQ_iIMGQeFFq]JGXGTIwSPhREVEa}fIQiBDaI@EgYGIAqNGqQbLwGTIgKCLwKMFw?AFXc\\Kg{QHx_gaqkka`kycqP@bAOu", 
+  ":~?@E`OAG?WgEb?Q?ahCBcogOdPEHe@CV`PaT`wcSdwW\\g?uXbpUCCh}Qc@QLGqUNEgC_gG_\\c`mmBqiEFg_j`qUMDaigJAuCGgKFIXOYHGGRfrEeJWGKJWKwaqOo_A}DGWkZFGC`LwcUJh?xNWGMLGozNgkVF~", 
+  ":~?@EaOYO@omCcoYI`OaVBWwRe_UAeXwMc`qBCxyCbpk\\_`A?a?qEd`]X_OyLaAEPDa]??aE@APQJBG?@`pE]dpkh_qSpa`QIIrMUJBMXFAAdIGkYHgSLIXsaIwKQKH_ibpScb?{^c`guaPsf`qGq`Bg~", 
+  ":~?@EbOcJ_?qOBwaJe?{OagSO_X]CDwS[_wiTGG_J`@MA@xSZHHE^_OQFF@}VFggY``MejGAUJQ}EEQ]@FWIBAPQfJZMHIamQCqMDIBUaHayE@o}?CPmKEA}_GWoLDGGrcbX?a?w}_pWXdbGud@Sm", 
+  ":~?@E`?EKAWwJ`GeDB?uKaxSF`xUX?_UGeXA?FH{ZapMBDxw`_w_SGiWE`O}[_PYLFXgdIh]BC`y@caaSEAy_HX}?BaMOCqqGFbITEwgY`aYIDAyNLgOdIY}bHa]AAOyIFrEgLrq?KbqLEG[WMGGEOhWkMn"
 ]


### PR DESCRIPTION
Algoritem je končal s poskušanjem barvanja preostalih štirih grafov na 70 vozliščih - brez uspeha, tako da so bili dodani v `seznam_protiprimerov3.json`. Prav tako ni uspel pobarvati še dveh grafov na 80 in 90 vozliščih, ki sta zdaj v `seznam_protiprimerov.json`.